### PR TITLE
[Fix] E2E Intermittent app loading - deleteme

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-latest, ubuntu-20.04]
+        os: [macos-10.15]
 
     name: RD E2E Test - ${{ matrix.os}}
     steps:


### PR DESCRIPTION
## Changes
1. Replaced the `ipcRenderer.SendSync('settings-read')` to `ipcRenderer.invoke('settings-read')`. --> Attempt to reduce the racing condition in order to collect the correct `settings` object.

### Possible root cause
Possible root cause related to the error: `Cannot read property 'type' of null`
* The method that collect the version/telemetry could be facing an racing condition running along with the test runner. The intermittence had reduced from 20% to 5% replacing the ipcRenderer to invoke instead SendSync.

### Images/Logs
Local intermittent issue:
![Screen Shot 2021-10-21 at 1 55 20 PM](https://user-images.githubusercontent.com/37411123/138347788-489199a5-dd77-437e-b862-05633a1c61f7.png)
![Screen Shot 2021-10-21 at 2 00 07 PM](https://user-images.githubusercontent.com/37411123/138352045-24a573b6-c973-4765-b876-dde81be13e47.png)
![Screen Shot 2021-10-21 at 2 03 33 PM](https://user-images.githubusercontent.com/37411123/138351996-da69c32d-76f0-46ba-9365-50af8ca51f74.png)

### Tests
With `ipcRenderer.invoke` --> Object loaded properly
![Screen Shot 2021-10-22 at 4 07 39 PM](https://user-images.githubusercontent.com/37411123/138530558-68c1d629-6d9e-485f-b19e-fe72bad69b71.png)

With `ipcRendere.SendSync` --> Object `null` - promise "pending"
![Screen Shot 2021-10-22 at 4 44 17 PM](https://user-images.githubusercontent.com/37411123/138530731-d43d282a-0c33-4b81-bb87-ae19f0978050.png)

**GitActions**
https://github.com/evertonlperes/rancher-desktop/actions/runs/1374095737