### PR TITLE
CIRRUS CI - RD SANDBOX

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,6 +69,8 @@ task:
 
   on_failure: 
     # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197
-    custom_script: cp -R /home/ranchertest/e2e/reports/ .
+    custom_script: |
+      mkdir e2e/reports/ 
+      cp -R /home/ranchertest/e2e/reports/* /tmp/cirrus-ci-build/e2e/reports/
     playwright_artifacts:
-      path: "/reports/*"
+      path: "/tmp/cirrus-ci-build/e2e/reports/*"


### PR DESCRIPTION
DON'T DELETE
Used only for CI tests and validations.